### PR TITLE
(feat)!: Async Render

### DIFF
--- a/lib/components/svg.ts
+++ b/lib/components/svg.ts
@@ -155,7 +155,28 @@ export type SvgBuilder = (
   | Promise<undefined>
   | Promise<SvgBuilderPostLoop>
 
-export type SvgBuilderPostLoop = (() => void) | (() => Promise<void>)
+export type PostLoopContext = {
+  /**
+   * The rendered SVG as a string.
+   */
+  rendered: string
+  /**
+   * The directory the SVG was written to.
+   */
+  dirname: string
+  /**
+   * The base name of the SVG file, without the extension.
+   */
+  basename: string
+  /**
+   * The full path to the SVG file.
+   */
+  filename: string
+}
+
+export type SvgBuilderPostLoop =
+  | ((context?: PostLoopContext) => void)
+  | ((context?: PostLoopContext) => Promise<void>)
 
 /**
  * @param {SvgAttributes} attributes

--- a/lib/components/svg.ts
+++ b/lib/components/svg.ts
@@ -147,16 +147,25 @@ export class Svg extends ShapeContainer {
   }
 }
 
-export type SvgBuilder = (svg: Svg) => undefined | SvgBuilderPostLoop
+export type SvgBuilder = (
+  svg: Svg,
+) =>
+  | undefined
+  | SvgBuilderPostLoop
+  | Promise<undefined>
+  | Promise<SvgBuilderPostLoop>
 
-export type SvgBuilderPostLoop = () => void
+export type SvgBuilderPostLoop = (() => void) | (() => Promise<void>)
 
 /**
  * @param {SvgAttributes} attributes
  * @param {SvgBuilder} builder
  */
-export function svg(attributes: SvgAttributes, builder: SvgBuilder): Svg {
+export async function svg(
+  attributes: SvgAttributes,
+  builder: SvgBuilder,
+): Promise<Svg> {
   const s = new Svg(attributes)
-  builder(s)
+  await builder(s)
   return s
 }

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -6,7 +6,7 @@
 
 import { mkdir, writeFile } from 'node:fs/promises'
 import { exec } from 'node:child_process'
-import { basename, extname, join } from 'node:path'
+import { basename, extname, join, resolve } from 'node:path'
 import { Svg, SvgAttributes, SvgBuilder } from './components/index.js'
 
 const NOOP = () => {}
@@ -60,13 +60,13 @@ export async function renderSvg(
     const svg = new Svg(svgAttributes)
     loops++
     const sketchFilename = basename(process.argv[1], extname(process.argv[1]))
-    await mkdir(join(renderDirectory, sketchFilename), { recursive: true })
+    const dirname = resolve(join(renderDirectory, sketchFilename))
+    await mkdir(dirname, { recursive: true })
     const postLoop = (await builder(svg)) ?? NOOP
-    const filename = join(
-      renderDirectory,
-      sketchFilename,
-      `${timestamp()}-${svg.formatFilenameMetadata()}.svg`,
-    )
+    const baseFilename = [timestamp(), svg.formatFilenameMetadata()]
+      .filter(Boolean)
+      .join('-')
+    const filename = join(dirname, `${baseFilename}.svg`)
     rendered = svg.render()
     await writeFile(filename, rendered)
     if (openEveryFrame) {
@@ -76,7 +76,12 @@ export async function renderSvg(
     if (logFilename) {
       console.log(filename)
     }
-    await postLoop()
+    await postLoop({
+      rendered,
+      dirname,
+      basename: baseFilename,
+      filename,
+    })
   }
   return rendered
 }

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -44,7 +44,7 @@ export function timestamp(d = new Date()): string {
 /**
  * @returns the most recent rendered SVG
  */
-export function renderSvg(
+export async function renderSvg(
   {
     loopCount = 1,
     openEveryFrame = true,
@@ -53,7 +53,7 @@ export function renderSvg(
     ...svgAttributes
   }: SvgAttributes & RenderLoopOptions,
   builder: SvgBuilder,
-): string {
+): Promise<string> {
   let loops = 0
   let rendered = ''
   while (loops < loopCount) {
@@ -61,7 +61,7 @@ export function renderSvg(
     loops++
     const sketchFilename = basename(process.argv[1], extname(process.argv[1]))
     mkdirSync(join(renderDirectory, sketchFilename), { recursive: true })
-    const postLoop = builder(svg) ?? NOOP
+    const postLoop = (await builder(svg)) ?? NOOP
     const filename = join(
       renderDirectory,
       sketchFilename,
@@ -76,7 +76,7 @@ export function renderSvg(
     if (logFilename) {
       console.log(filename)
     }
-    postLoop()
+    await postLoop()
   }
   return rendered
 }

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -4,8 +4,8 @@
  * This file is exported separately from the rest of the lib to isolate Node.js dependencies.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { exec } from 'node:child_process'
 import { basename, extname, join } from 'node:path'
 import { Svg, SvgAttributes, SvgBuilder } from './components/index.js'
 
@@ -60,7 +60,7 @@ export async function renderSvg(
     const svg = new Svg(svgAttributes)
     loops++
     const sketchFilename = basename(process.argv[1], extname(process.argv[1]))
-    mkdirSync(join(renderDirectory, sketchFilename), { recursive: true })
+    await mkdir(join(renderDirectory, sketchFilename), { recursive: true })
     const postLoop = (await builder(svg)) ?? NOOP
     const filename = join(
       renderDirectory,
@@ -68,10 +68,10 @@ export async function renderSvg(
       `${timestamp()}-${svg.formatFilenameMetadata()}.svg`,
     )
     rendered = svg.render()
-    writeFileSync(filename, rendered)
+    await writeFile(filename, rendered)
     if (openEveryFrame) {
       const command = process.platform === 'win32' ? 'start' : 'open'
-      execSync(`${command} "${filename}"`)
+      exec(`${command} "${filename}"`)
     }
     if (logFilename) {
       console.log(filename)


### PR DESCRIPTION
This is a significant breaking API change, but it's probably worth it because nobody uses this lib.

If somebody does use this lib and this causes issues for them, I'd love to hear about it in the form of an issue. Until then I have to assume that nobody uses this lib, and I should prioritize my own happiness.

This API makes way more sense and therefore I think I will pursue it.

# Documentation updates required

## [Rendering sketches](https://github.com/ericyd/salamivg/wiki/Rendering-sketches)

Replace

```
This returns a string representation of the tag, including all it's attributes and children.
```

with

```
This returns a `Promise<string>` representation of the tag, including all it's attributes and children.
```

## SVG Builder Post Loop

The "post loop" also receives contextual arguments which can be useful when operating on the resulting SVG:

- `rendered`: the full rendered SVG string. Can be passed to other programs for post-processing.
- `dirname`: the absolute directory to which the SVG was written.
- `basename`: the file name without the directory or extension.
- `filename`: the absolute file name including directory and extension.

## Add section on async rendering

Async rendering

`renderSvg` can be used with synchronous or asynchronous builder callbacks.

A basic (contrived) async implementation looks like this

```js
import crypto from "node:crypto";
import { promisify } from "node:util";
import { renderSvg, createRng, random } from "./dist/index.js";

const randomBytes = promisify(crypto.randomBytes);

let seed = [0];

renderSvg({ loopCount: 2 }, async (svg) => {
  seed = await randomBytes(1);
  const rng = createRng(seed[0].toString());
  svg.circle({ x: 50, y: 50, radius: random(0, 100, rng), fill: "#c55" });

  return async () => {
    seed = await randomBytes(1);
  };
});
```

A more useful example might be rendering a raster image. For example, you might use [resvg](https://github.com/linebender/resvg) to render the output:

```js
import crypto from 'node:crypto'
import { promisify } from 'node:util'
import { renderSvg, createRng, random } from '@salamivg/core'
import childProcess from 'node:child_process'
import { join } from 'node:path'

const randomBytes = promisify(crypto.randomBytes)
const exec = promisify(childProcess.exec)

let seed = [0]

renderSvg({ loopCount: 2 }, async (svg) => {
  seed = await randomBytes(1)
  const rng = createRng(seed[0].toString())
  svg.circle({ x: 50, y: 50, radius: random(10, 50, rng), fill: '#c55' })

  return async ({ dirname, basename, filename }) => {
    seed = await randomBytes(1)
    await exec(`resvg "${filename}" "${join(dirname, `${basename}.png`)}"`)
  }
})
```

Or, you could use the [@resvg/resvg-js](https://www.npmjs.com/package/@resvg/resvg-js) package:

```js
import crypto from 'node:crypto'
import { promisify } from 'node:util'
import { renderSvg, createRng, random } from './dist/index.js'
import childProcess from 'node:child_process'
import { join } from 'node:path'
import { writeFile } from 'node:fs/promises'
import { Resvg } from '@resvg/resvg-js'

const randomBytes = promisify(crypto.randomBytes)
const exec = promisify(childProcess.exec)

let seed = '0000000000000000'

renderSvg({ loopCount: 1 }, async (svg) => {
  const rng = createRng(seed)
  svg.circle({ x: 50, y: 50, radius: random(10, 50, rng), fill: '#c55' })

  return async ({ dirname, basename, rendered }) => {
    const opts = {
      background: 'rgba(238, 235, 230, .9)',
      fitTo: {
        mode: 'width',
        value: 1200,
      },
    }
    const resvg = new Resvg(rendered, opts)
    const pngData = resvg.render()
    const pngBuffer = pngData.asPng()

    console.info('Original SVG Size:', `${resvg.width} x ${resvg.height}`)
    console.info('Output PNG Size  :', `${pngData.width} x ${pngData.height}`)

    await writeFile(join(dirname, `${basename}.png`), pngBuffer)
  }
})
```

## [FAQ: Bun Example](https://github.com/ericyd/salamivg/wiki/FAQ#bun-example)

```js
// sketch.js
import { svg } from '@salamivg/core'

const result = await svg({ width: 100, height: 100 }, async (it) => {
  it.circle({ x: 50, y: 50, radius: 50, fill: '#c55' })
})
const drawing = result.render()

await Bun.write('my.svg', drawing)
```

## [FAQ: Deno Example](https://github.com/ericyd/salamivg/wiki/FAQ#deno-example)

```js
// sketch.js
import { svg } from 'https://github.com/ericyd/salamivg/raw/main/lib/index.js'

const result = await svg({ width: 100, height: 100 }, async (it) => {
  it.circle({ x: 50, y: 50, radius: 50, fill: '#c55' })
})
const drawing = result.render()

await Deno.writeTextFile("my.svg", drawing);
```